### PR TITLE
add kafka producer python function #38

### DIFF
--- a/src/model/fastapi/kafkaProducer.py
+++ b/src/model/fastapi/kafkaProducer.py
@@ -1,0 +1,31 @@
+from kafka import KafkaProducer
+from json import dumps
+import time
+
+# 사용 라이브러리 -> pip install kafka-python 
+# 서버 주소는 클라우드 배포 이후 변경 예정
+
+# Parameter 값 설명
+# cameraId => 임의로 보내는 카메라 Id 값 (하나의 모델이라고 가정시 같은 Integer 값으로 보내면 된다.)
+# interestPeopleCnt => 등장한 인물의 관심 있는 것으로 추정되는 프레임의 개수 (int)
+# arriveTime ->  인물의 등장 시간 - time.localtime() 형식 (문제 있을 시 변경 요청 해주셔도 됩니다.)
+# leaveTime -> 인물의 퇴장 시간 - time.localtime()
+# staringframeData -> 인물 등장 관련 0,1 표현 데이터 리스트 
+
+def kafkaSend(cameraId, interestPeopleCnt, passedPeopleCnt, arriveTime, leaveTime, staringframeData):
+    producer = KafkaProducer(
+    acks=0, 
+    compression_type='gzip', 
+    bootstrap_servers=['localhost:9092'],
+    value_serializer=lambda x:dumps(x).encode('utf-8') 
+    )
+    
+    data = {'cameraId' : cameraId, 'startAt' : arriveTime, 'leaveAt' : leaveTime, 'passedPeopleCnt' : passedPeopleCnt, 'interestPeopleCnt' : interestPeopleCnt, "staringData" : staringframeData}
+    producer.send('drm-face-topic', value=data)
+    producer.flush() 
+    
+    
+
+if __name__ == '__main__':
+    exampleTime =  time.localtime(time.time()) 
+    kafkaSend(0, 12, 30, exampleTime, exampleTime, [0,0,0,1,1,1,0])


### PR DESCRIPTION
## 관련 이슈 번호

#38 을 위한 kafka producer 코드 추가
해당 함수를 이용해서, 모델 서버는 카프카로 데이터를 송신할 수 있음.

기타 내부 파라미터는 주석을 참고.
또는 수정 원할시 @donggook-me 에게 이야기 해주세요.

해당 함수 사용하기 위해, pip install kafka-python 해야 합니다.
requirements.txt 에 이것도 추가해주시면 될 것 같습니다.

## PR 종류
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] application / infrastructure changes
- [ ] Other... Please describe:

## 리뷰어에게 남길 말
pip install kafka-python 잊지 마시길...

지금은 카프카 서버가 클라우드에 올리기 전이라, 테스트하시긴 어려울 것 같고요.
클라우드 올린 다음에 같이 해보죠. 

## PR 체크리스트
- [x] The commit message follows our guidelines: https://github.com/kookmin-sw/capstone-2024-04/blob/master/.gitmessage.txt
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)