### PR TITLE
#129 fps 반영한 평균 시간 계산 코드 수정

### DIFF
--- a/src/server/src/main/java/com/drm/server/domain/dailyMediaBoard/DailyMediaBoard.java
+++ b/src/server/src/main/java/com/drm/server/domain/dailyMediaBoard/DailyMediaBoard.java
@@ -70,8 +70,12 @@ public class DailyMediaBoard extends BaseTimeEntity {
         this.hourlyInterestedCount.set(hour, this.hourlyInterestedCount.get(hour) + 1);
     }
 //    시간별 평균 시선시간
-    public void updateHourlyAvgStaringTime(int hour, float staringTime) {
-        this.hourlyAvgStaringTime.set(hour, ((this.hourlyAvgStaringTime.get(hour) *  this.getHourlyInterestedCount().get(hour) + staringTime ) / (this.getHourlyInterestedCount().get(hour) + 1)  ));
+// fps > 1 인 상황에 대응하기 위해 CaptureCount * (1/fps) 를 곱해주는 것으로 수정
+// ex: fps = 25 인 경우 -> CaptureCount 10 일시 -> 10 * (1/25) = 0.4초 응시
+    public void updateHourlyAvgStaringTime(int hour, float staringTime, int fps) {
+        float staringCalculatedTime = staringTime * (1/fps);
+        this.hourlyAvgStaringTime.set(hour, ((this.hourlyAvgStaringTime.get(hour) *  this.getHourlyInterestedCount().get(hour) + staringCalculatedTime)
+                / (this.getHourlyInterestedCount().get(hour) + 1)  ));
     }
 
 //    연령대별 관심 수
@@ -98,9 +102,12 @@ public class DailyMediaBoard extends BaseTimeEntity {
     public void addTotalPeopleCount() {
         this.totalPeopleCount +=1;
     }
-//    평균응시시간은 전체 관심있는 인원으로 평균값설정
-    public void updateAvgStaringTime(int faceCaptureCount) {
-        this.avgStaringTime = ((this.getAvgStaringTime() * (this.maleInterestCnt + this.femaleInterestCnt))+faceCaptureCount) / ((this.maleInterestCnt + this.femaleInterestCnt)+ 1);
+    // 평균응시시간은 전체 관심있는 인원으로 평균값설정
+    // fps > 1 인 상황에 대응하기 위해 CaptureCount * (1/fps) 를 곱해주는 것으로 수정
+    // ex: fps = 25 인 경우 -> CaptureCount 10 일시 -> 10 * (1/25) = 0.4초 응시
+    public void updateAvgStaringTime(int faceCaptureCount, int fps) {
+        float faceCaptureSec = faceCaptureCount * (1/fps);
+        this.avgStaringTime = ((this.getAvgStaringTime() * (this.maleInterestCnt + this.femaleInterestCnt))+faceCaptureSec) / ((this.maleInterestCnt + this.femaleInterestCnt)+ 1);
     }
 
     public void updateAvgAge(int age) {

--- a/src/server/src/main/java/com/drm/server/service/DailyMediaBoardService.java
+++ b/src/server/src/main/java/com/drm/server/service/DailyMediaBoardService.java
@@ -38,9 +38,9 @@ public class DailyMediaBoardService {
         dailyMediaBoard.updateAvgAge(detectedFace.getAge());
 //        관심이 있다
         if(detectedFace.getFaceCaptureCnt() > 0){
-            dailyMediaBoard.updateAvgStaringTime(detectedFace.getFaceCaptureCnt()); //평균시선 시간
+            dailyMediaBoard.updateAvgStaringTime(detectedFace.getFaceCaptureCnt(), detectedFace.getFps()); //평균시선 시간
             dailyMediaBoard.updateInterestedAgeRangeCount(ageRange); //연령대별 관심인구수
-            dailyMediaBoard.updateHourlyAvgStaringTime(dataHour, detectedFace.getFaceCaptureCnt()); //시간별 평균시선
+            dailyMediaBoard.updateHourlyAvgStaringTime(dataHour, detectedFace.getFaceCaptureCnt(), detectedFace.getFps()); //시간별 평균시선
             dailyMediaBoard.addHourlyInterestedCount(dataHour); // 시간별 관심인구
 
             if(detectedFace.isMale()){


### PR DESCRIPTION
## 관련 이슈 번호
_이 Pull Request와 관련있는 이슈 번호를 적어주세요._<br />
_이슈 또는 PR 번호 앞에 #을 붙이시면 제목을 바로 확인하실 수 있습니다. (예. #999 )_

#129 

## PR 종류
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] application / infrastructure changes
- [ ] Other... Please describe:

## PR 설명
_이 PR로 무엇이 달라지는지 대략적으로 알려주세요._

fps 에 맞춰서 평균 시간 / 시간대별 평균 시간 계산하도록 로직을 수정하였습니다. 
fps 를 반영해야 하는 데이터값은 평균 시간 외엔 없습니다.

또한 detectedFace 자체에는 fps 고려한 데이터값은 없습니다.
따라서 detectedFace -> daily_media_board 로 Update 갱신하는 함수의 일부를 수정했습니다.

기존엔 fps = 1 인 상황만을 가정하여 CaptureCnt 3이면 3초 쳐다보는 식의 로직이었으나,
Capturecnt * (1 / fps) 식으로 수정하여, ex: fps = 25 일시 CaptureCnt * 0.04 초 = 응시 시간으로 추가되도록 수정되었습니다.



## 리뷰어에게 남길 말
_코드 리뷰를 할 경우 유의사항을 적어주세요._

@ssoree912 
**해당 코드 수정 한번 확인해주시고, 문제 없다고 판단될시 Merge 해주세요.**

